### PR TITLE
Bug 009 - Fixing Auth Integration Tests

### DIFF
--- a/src/test/java/org/example/integration/AuthorizationIntegrationTest.java
+++ b/src/test/java/org/example/integration/AuthorizationIntegrationTest.java
@@ -33,13 +33,13 @@ public class AuthorizationIntegrationTest {
 
         );
         String token = "Bearer " + client
-                .target("http://localhost:8080/api/auth/login")
+                .target(System.getenv("API_URL")+"auth/login")
                 .request()
                 .post(Entity.json(loginRequest))
                 .readEntity(String.class);
 
         Response response = client
-                .target("http://localhost:8080/api/job-roles")
+                .target(System.getenv("API_URL")+"job-roles/?page=1&limit=10")
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, token)
                 .get();
@@ -59,13 +59,13 @@ public class AuthorizationIntegrationTest {
 
         );
         String token = "Bearer " + client
-                .target("http://localhost:8080/api/auth/login")
+                .target(System.getenv("API_URL")+"auth/login")
                 .request()
                 .post(Entity.json(loginRequest))
                 .readEntity(String.class);
 
         Response response = client
-                .target("http://localhost:8080/api/job-roles")
+                .target(System.getenv("API_URL")+"job-roles/?page=1&limit=10")
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, token)
                 .get();
@@ -80,7 +80,7 @@ public class AuthorizationIntegrationTest {
         Client client = APP.client();
 
         Response response = client
-                .target("http://localhost:8080/api/job-roles")
+                .target(System.getenv("API_URL")+"job-roles/?page=1&limit=10")
                 .request()
                 .get();
 

--- a/src/test/java/org/example/integration/JobRolesIntegrationTest.java
+++ b/src/test/java/org/example/integration/JobRolesIntegrationTest.java
@@ -27,32 +27,6 @@ public class JobRolesIntegrationTest {
     );
 
     @Test
-    void getAllJobRoles_shouldReturnAllJobRoles() {
-
-        Client client = APP.client();
-
-        LoginRequest loginRequest = new LoginRequest(
-                "admin@kainos.com",
-                "wlSNgEn5dCBM59jnbeH+txKWn36Vt6QScELcAa5ZBNduqSY16JAl2hqeGsZrmpG0kdb9+ILMoCJVB3er8ZoCJI9o26IM83UfnJtTT3p7cRgOUxsU0iMHgkI9KdQpDim6"
-
-        );
-        String token = "Bearer " + client
-                .target(System.getenv("API_URL")+"auth/login")
-                .request()
-                .post(Entity.json(loginRequest))
-                .readEntity(String.class);
-
-        Response response = client
-                .target(System.getenv("API_URL")+"job-roles")
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .get();
-
-        Assertions.assertEquals(200, response.getStatus());
-
-    }
-
-    @Test
     void getJobRoleById_shouldReturnAJobRole() {
 
         Client client = APP.client();
@@ -98,7 +72,8 @@ public class JobRolesIntegrationTest {
 
         Response response = client
                 .target(System.getenv("API_URL")+"job-roles/?page=1&limit=10")
-                .request(HttpHeaders.AUTHORIZATION, token)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .get();
 
         System.out.println(response);
@@ -126,7 +101,8 @@ public class JobRolesIntegrationTest {
 
         Response response = client
                 .target(System.getenv("API_URL")+"job-roles/?page=1&limit=25")
-                .request(HttpHeaders.AUTHORIZATION, token)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .get();
 
         System.out.println(response);
@@ -154,7 +130,8 @@ public class JobRolesIntegrationTest {
 
         Response response = client
                 .target(System.getenv("API_URL")+"job-roles/?page=1&limit=50")
-                .request(HttpHeaders.AUTHORIZATION, token)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .get();
 
         System.out.println(response);
@@ -182,7 +159,8 @@ public class JobRolesIntegrationTest {
 
         Response response = client
                 .target(System.getenv("API_URL")+"job-roles/?page=1&limit=100")
-                .request(HttpHeaders.AUTHORIZATION, token)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, token)
                 .get();
 
         System.out.println(response);


### PR DESCRIPTION
- Changed hardcoded URLs in Authorization tests to use Environment variables
- Fixed error with the login token being passed in the incorrect position in the JobRole tests, causing a 400 error.
- Removed getAllJobRoles integration test, as a page and limit must be included in GET request, and other tests cover the same area.